### PR TITLE
Korrektur der Icon-Links von 4bhif zu 3ahitm

### DIFF
--- a/asciidocs/docs/index.adoc
+++ b/asciidocs/docs/index.adoc
@@ -8,8 +8,8 @@ ifndef::imagesdir[:imagesdir: images]
 :toc:
 ifdef::backend-html5[]
 // https://fontawesome.com/v4.7.0/icons/
-icon:file-text-o[link=https://github.com/2324-4bhif-wmc/2324-4bhif-wmc-lecture-notes/main/asciidocs/{docname}.adoc] ‏ ‏ ‎
-icon:github-square[link=https://github.com/2324-4bhif-wmc/2324-4bhif-wmc-lecture-notes] ‏ ‏ ‎
+icon:file-text-o[link=https://github.com/2425-3ahitm-itp/2425-3ahitm-itp-lecture-notes/blob/main/asciidocs/docs/{docname}.adoc] ‏ ‏ ‎
+icon:github-square[link=https://github.com/2425-3ahitm-itp/2425-3ahitm-itp-lecture-notes] ‏ ‏ ‎
 icon:home[link=http://edufs.edu.htl-leonding.ac.at/~t.stuetz/hugo/2021/01/lecture-notes/]
 endif::backend-html5[]
 


### PR DESCRIPTION
Änderung der Icon-Links auf die Klasse 3ahitm und Jahr 24/25

<img width="727" alt="Screenshot 2024-11-02 at 5 11 35 PM" src="https://github.com/user-attachments/assets/b8cb3b03-91c1-472c-bd33-23b64ed1b634">

- GitHub-Repo verlinkt zum neuen Repository: `2425-3ahitm-itp/2425-3ahitm-itp-lecture-notes`
- File-Text verlinkt zur ADOC-File im neuen Repository: 
  https://github.com/2425-3ahitm-itp/2425-3ahitm-itp-lecture-notes/blob/main/asciidocs/docs/index.adoc

